### PR TITLE
fix: replace hardcoded home path with ~ in excludesfile

### DIFF
--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -3,7 +3,7 @@
 	email = kz@assaulter.org
 [core]
 	trustctime = false
-	excludesfile = /Users/kazukikubo/.gitignore_global
+	excludesfile = ~/.gitignore_global
 [difftool "sourcetree"]
 	cmd = opendiff \"$LOCAL\" \"$REMOTE\"
 	path = 


### PR DESCRIPTION
## Summary

- `.gitconfig` の `excludesfile` が `/Users/kazukikubo/.gitignore_global` とハードコードされており、他のマシンで動作しない
- `~/.gitignore_global` に変更してポータブルにする

## Test plan

- [x] 別マシンで `homeshick link my_castle` 後、`git config core.excludesfile` が `~/.gitignore_global` を返すことを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)