### PR TITLE
fix: remove Volta, use mise as single Node.js manager

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -70,9 +70,6 @@ source "$HOME/.homesick/repos/homeshick/homeshick.sh"
 # java
 export PATH="/usr/local/opt/openjdk/bin:$PATH"
 
-export VOLTA_HOME="$HOME/.volta"
-export PATH="$VOLTA_HOME/bin:$PATH"
-
 # mise
 eval "$(mise activate zsh)"
 export PATH="$HOME/.mint/bin:$PATH"


### PR DESCRIPTION
## Summary

- `mise` の `config.toml` で `node = "latest"` を管理しているにもかかわらず、`.zshrc` に Volta の設定も残っており競合していた
- Volta の `PATH` 設定を削除し、mise に一本化する

## Test plan

- [x] `node -v` が mise 管理のバージョンを返すことを確認
- [x] `which node` が `~/.local/share/mise/...` 配下を指すことを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)