### PR TITLE
chore: remove defunct gcc alias and stale GOROOT comments

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -27,7 +27,6 @@ alias chrome='open -a Gooogle\ Chrome'
 alias kobito='open -a Kobito'
 alias be='bundle exec'
 alias g='git'
-alias gcc=llvm-gcc
 
 #--- paths ---#
 typeset -U path PATH
@@ -47,8 +46,6 @@ path=(
 ### for go lang
 export GOPATH=$HOME/go
 export PATH=$PATH:$GOPATH/bin
-# export GOROOT=$(go1.18 env GOROOT)
-# export PATH=$PATH:$GOROOT:bin
 
 #--- その他ツール ---#
 # editor


### PR DESCRIPTION
## Summary

- `alias gcc=llvm-gcc` を削除: `llvm-gcc` は現代の macOS に存在せず、エイリアスが機能しない
- コメントアウトされた `GOROOT` の2行を削除: Go 1.18 固有の設定で現在は不要

## Test plan

- [x] `gcc` コマンドが Homebrew の `gcc` または Xcode CLT のものを正常に指すことを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)